### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,77 +1,33 @@
-[Solid](https://github.com/solid) is an initiative led by Tim Berners-Lee with the goal of decentralising power on the web to ensure that the web is used for the global public interest as defined by the [Solid values](https://github.com/solid/community/blob/master/solid-values.md). Currently, Solid is ready for developers to build on Solid rather than end users. 
+The [Solid GitHub account](https://github.com/solid) was started by the [Solid academic project at MIT](https://solid.mit.edu). In summer 2018 the private company [inrupt](https://inrupt.com) based in Boston, USA, made significant contributions to the [Solid GitHub account](https://github.com/solid).
 
-[Solid Opening Hours](https://zoom.us/j/334489790) are a chance to chat with the Solid Team. You can tune in every Tuesday at 15.30 CET for an hour.
+The [Solid GitHub account](https://github.com/solid) includes the following. 
 
-[Solid World](https://www.eventbrite.com/e/solid-world-tickets-53692744444?aff=erellivmlt) is a podcast where you can get up to speed with Solid and tune into the latest conversations. You can also read the latest [status update](https://github.com/solid/information/blob/master/status.md) 
+# Solid Specifications 
+T specifications. 
 
-The [Solid Team](solid-team.md) has a closed gitter chat and there are weekly recurring [Solid support meetings](https://github.com/solid/information/blob/master/solid-support-agenda-and-minutes.md) via online calls moderated by the Solid Manager. Individuals with specified Solid roles need to attend the Solid support meetings if stated in their role description. The roles and responsibilites of the Solid Team are defined by the Solid Leader who also appoints individuals to those roles. If you would like to apply for a role, [contact the Solid Manager](solid-team.md) with your cv and motivation statement.
+# Information about Solid
+Information about Solid  can be found in the following repos:
+information, vocab, solid-tutorial-intro, solid-tutorial-angular, solid-tutorial-rdflib.js, profile-viewer-tutorial, understanding-linked-data, solid-tutorial-pastebin, web-summit-2018, intro-to-sohe Solid specifications can be found in the following repos: 
+* [Solid](https://github.com/solid/solid-spec)
+* [Web Access Control](https://github.com/solid/web-access-control-spec)
+* [WebID OIDC](https://github.com/solid/webid-oidc-spec)) 
 
-Solid specs, code, copy, and logo are open source and [licensed](licence.md) under the MIT license. There are defined [Solid logo usage guidelines](https://github.com/solid/information/blob/master/solid-logo-usage-guidelines.md). 
+The [Solid Team](solid-team.md) works with the [W3C Solid Community Group](https://www.w3.org/community/solid/) (which you can also read about on the [Solid/information solid.md](solid.md) to support the development of the Solid specifications as well as coordinating those who are implementing the Solidlid-slides, releases, solid-architecture, user guide, solid-namespace, solid-platform, solid-apps, and solid.mit.edu
 
-## Press
-The Solid Team occasionally give talks or write articles. You can find out about [upcoming talks](https://github.com/solid/information/blob/master/solid-team-talks.md) as well as see recordings of past talks on [Solid Resources](https://github.com/solid/information/blob/master/solid-resources.md). If you would like to invite one of the [Solid team](https://github.com/solid/information/blob/master/solid-team.md) for public speaking or for an interview for an article please [contact the Solid Manager](https://github.com/solid/information/blob/master/solid-roles.md) and provide the details.
+Currently there is no defined individual responsible for these repositories, although anyone can suggest to update the information by submitting a pull request or issue. If you would like to become responsible for these repositories including keeping the information up to date and incorporating suggestions from pull requests and issues contact the Solid Manager. The information in these repositories can also be found in the [W3C Solid Community Group](https://www.w3.org/community/solid/). 
 
-## Solid Events
-[Solid Events](solid-events.md) provide an opportunity for anyone to meet and talk about Solid in person. 
+# Implementations of the Solid Specifications
+The implementation of the Solid specifications can be found in the following repos:
+oidc-auth-manager, solid-multi-rp-client, folder-pane, pane-registry, oidc-rs, keychain, solid-pane, solid-notifications, solid-profile-ui, solid-connections-ui, pane-source, jose, solid-inbox, oidc-op, solid-tif, solid-client, oidc-rp, issue-panes, solid, solid-idp-list, kvplus-files, solid-email, oidc-web, solid-sign-up, solid, takeout-import, node-solid-ws, solid-auth-tls,  solid-auth-oidc, meeting-pane, solid-dips, solid-cli, solid-web-client, solid-permissions, acl-check, node-solid-server, solid-auth-client, wac-allow, mavo-solid, solid-auth-client, ldflex-playground, query-ldflex, react-components, profile-viewer-react, solid, solid-panes, solid-ui, mashlib
 
-Anyone can organise a Solid Event. 
+[Projects](https://github.com/orgs/solid/projects) with defined aims, managers, and teams, as described in the project descriptions work on the implementations of the Solid specification. The Project Manager is responsible for determining the scope of a [project](https://github.com/orgs/solid/projects) as well as supporting the coordination of the Project Team Member. The Project Manager will ensure that any issues and pull requests related to their project are assigned to Project Team Member, ensure that those assigned are on the case, and are responsible for merging pull requests and closing issues associated to their project. A Project Manager has admin rights over the project they manage. A Project Team Member is working on a specific official Solid [project](https://github.com/orgs/solid/projects). Project Team Members may have issues assigned to them by the Project  Manager. Project Team Members have admin rights of projects they are working on. If you would like to join an existing project, reach out to corresponding Project Manager. If you would like to start a new project, reach out to the Solid Manager with your project proposal including a defined aim, Project Manager, and Project Team.
 
-You can read [guidance](solid-event-guidance.md) from previous event organiser, which you can also contribute to once you have completed your Solid Event. 
+# Gitter Chat 
+The  Gitter chats associated to the [Solid GitHub account](https://github.com/solid) include: 
 
-If you are organising a Solid Event, [let others know about the details](solid-events.md). If you have shown demonstrable contributions judged by the Solid Team you will be invited to the closed Solid Event organisers gitter thread to talk with others who are building Solid app developers tools. 
-	
-# Solid Ecosystem
-Anyone can build on Solid, there are multiple ways in which you can build: 
- * [Solid Specifications](#solid-specifications)
- * [Pod Providers](#pod-providers)
- * [Solid Apps](#solid-apps)
- * [Solid Developer Tools](#solid-developer-tools)
- 
-Solid encourages you to keep the [code of conduct](code-of-conduct.md) in mind. If you are have a concern you can contact the Solid Team or submit and issue.
-
-[Discourse](https://forum.solidproject.org/), the [solid/chat](https://gitter.im/solid/chat) on gitter and [Reddit](https://www.reddit.com/r/SOLID) are great places to ask general questions which you can also search for on the [Frequently Unanswered Questions](https://github.com/solid/information/blob/master/frequently-unanswered-questions.md).
-
-User Testing is carried out to systematically test assumptions on a specific element. If you would like to become part of the User Testing Panel or would like to test an item that you hvave build on Solid [contact the Solid Manager](https://github.com/solid/information/blob/master/solid-team.md).
- 
-## Solid Specifications
-At the core of Solid are the Solid specifications: 
- - [Solid](https://github.com/solid/solid-spec)  
- - [Web Access Control](https://github.com/solid/web-access-control-spec) 
- - [WebID OIDC](https://github.com/solid/webid-oidc-spec) 
- 
-Terms used in the Solid specifications are defined in the [Solid Dictionary](https://github.com/solid/information/blob/master/solid-dictionary.md) and a full overview of the [architecture](https://github.com/solid/solid-architecture) explains how the Solid specifications are interrelated. 
-
-The Solid specifications are discussed and developed by the [W3C Solid Community Group](https://www.w3.org/information/solid/wiki/Main_Page) which is [open for anyone to join]. The Solid W3C Community Group communicates using a mailing list and biweekly hour long calls which you will be part of if you join. The [agenda and minutes](https://www.w3.org/community/solid/wiki/Meetings) for the calls are publicly available. 
-
-Changes to the spec are made using the following process: 
-
-Step 1. Making a Suggestion
-	If you would like to make a suggestion for a speific change to code or text submit a pull request and if you would like to raise a general point open an [issue](https://github.com/solid/information/tree/master/.github/ISSUE_TEMPLATE). 
-	
- Step 2. Inviting a Conversation around your Suggestion to Find Consensus
-	  Let others know about your suggestion by posting it on [solid/suggestions](https://gitter.im/solid/suggestions). Solid/suggestions is not a place to talk about the suggestion, this happens in the pull request or issue itself.How long does it take to process a suggestions? Pull requests and issues associated to the the spec (i.e. [solid spec](https://github.com/solid/solid-spec), [web access control spec](https://github.com/solid/web-access-control-spec), and [webid oidc spec](https://github.com/solid/webid-oidc-spec)) and the [Solid information repo](https://github.com/solid/information) need to be open for a minimum of three days to give other a chance to share their opinion to be considered. Pull requests and issues associated to all other repos can be closed immediately and do not have a minimum time they have to be left open unless they deviate from the spec in which case they need to be open for a minimum of three days. 
- 
- Step 3. Coming to a Conclusion through Compromise  
- 	Who is responsible for processing the suggestion? The repository manager of the repository to which the suggestion pertains to will be responsible for merging and closing the pull request or issue. If there is a difference of opinion, parties are encouraged to talk to find a compromise. If a compromise cannot be met the Solid Leader will make the final judgement.
-
-## Pod Providers 
-Users can either use a Pod Provider who self host. There is an open channel for people to talk about self hosting. 
-
-Anyone have become a Pod Provider. 
-
-There are example [Solid Servers](https://github.com/solid/solid) with [changelog](https://github.com/solid/node-solid-server/blob/release/v5.0.0/CHANGELOG.md) documenting the versions that can be used as a reference by Pod Providers. 
-
-If you are building a Pod, let others know about your [Pod Providers](pod-providers.md). If you have shown demonstrable contributions judged by the Solid Team you will be invited to the closed Pod Provider gitter thread to talk with other Pod Providers. 
-
-## Solid Apps  
-Anyone can build a Solid app. 
-
-If you are building a Solid app, let others know about your [Solid App](https://github.com/solid/solid-apps). If you have shown demonstrable contributions judged by the Solid Team you will be invited to the closed Solid app developer gitter thread to talk with other Solid app developers 
-
-## Solid Developer Tools
-Anyone can build Solid app developer tools. 
-
-If you are building a Solid app developer tools, let others know about your [Developer Support Tool Providers](https://github.com/solid/information/blob/master/developer-tools.md). If you have shown demonstrable contributions judged by the Solid Team you will be invited to the closed Solid app developer tools gitter thread to talk with others who are building Solid app developers tools. 
-
-# Solid Community 
-Solid Community are multiple organisations and individuals working as volunteers to building open source solutions based on the Solid specification. 
+* solid/chat: a place to talk about all things solid, open to all. 
+* solid/solid-spec: a place to talk about the solid spec, open to all. Note that actual changes to the Solid specification happen through the processes and channels explained in the W3C Solid Community Group
+* node-solid-server: a place to talk about the server implementation of the Solid specification, open to all. 
+* app-development: a place to talk about the implementation of the Solid specification when building applications, open to all. 
+* site-and-docs: a place to talk about sites and documentation associated to the solid GitHub account
+* solid/chat-app: a place to talk about the implementation of the Solid specification when building chat applications


### PR DESCRIPTION
Information is being doubled up in the W3C Solid Community Group wiki and the github.com/solid/information repo meaning there are two sources of truth which could result in confusion through divergence. 

The Solid GitHub account has multiple elements and an overview would help guide newcomers and give clarity on how to work together.