### PR TITLE
Update solid-team.md

### DIFF
--- a/solid-team.md
+++ b/solid-team.md
@@ -1,89 +1,41 @@
 # Solid Roles and Responsibilities  
-This document aims to identify the various roles within Solid,
-and the responsibilities associated with each role, where applicable.
+This document aims to identify the various roles within Solid, and the responsibilities associated with each role, where applicable.
 
 - [Solid Leader](#solid-leader)
 - [Solid Manager](#solid-manager)
-- [Repository Manager](#repository-manager)
-- [Core Contributor](#core-contributor)
-- [Project Release Manager](#project-release-manager)
-- [Project  Contributor](#project-contributor)
-- [User Testing Manager](#user-testing-Manager)
-- [User Testing Contributor](#user-testing-Contributor)
-- [Solid User Testing Panelist](#solid-user-testing-panelist)
-- [Solid Event Organiser](#solid-Event-Organiser)
+- [Solid Specifications Repository Manager](#repository-manager)
+- [Solid Experts](#solid-experts)
+- [Solid Advisor](#solid-advisor)
+- [Solid Event Organiser](#solid-event-organiser)
 
 ## Solid Leader
-The Solid Leader defines the governing vision of the Solid project. The Solid Leader is responsible for approving the descriptions of the responsibilities of the Solid team roles as well as appointing individuals to the roles. The Solid Leader is also responsible for approving changes to the Solid specifications and [official projects led by Solid](https://github.com/orgs/solid/projects). If there are differences of opinion, the Solid Leader has the final say on the way forward. The Solid Leader has admin rights of all Solid repositories. The Solid Leader can optionally attend the weekly recurring Solid support meeting, project meetings, and user testing meeting.
+The Solid Leader defines the governing vision of the Solid project. The Solid Leader is responsible for approving the descriptions of the responsibilities of the Solid team roles as well as appointing individuals to the roles. The decision of the Solid Leader around approving changes to the Solid specifications can override the decisions of the Solid Specifications Reposotory Manager. The decision of the Solid Leader around implementation of the Solid vision can override the decisions of the Solid Manager. If there are differences of opinion, the Solid Leader has the final say on the way forward. The Solid Leader has admin rights of all Solid repositories. 
 
 ## Solid Manager
-The Solid Manager implements the governing vision of the Solid project. The Solid Manager collects information from the Solid and puts it forward to the Solid Leader as a suggestion for final approval. The Solid Manager has admin rights of all Solid repositories and is responsible for coordination and collaboration. The Solid Manager is responsible for sharing the agenda prior to the Solid support meeting, incorporating suggestions to the agenda, sharing the minutes after the Solid support meeting and moderating the Solid support meeting. The Solid Manager is responsible for sharing the agenda prior, incorporating suggestions to the agenda, sharing the minutes after, and moderating the W3C Solid Community Group Call.
+The Solid Manager implements the governing vision of the Solid project. The Solid Manager is responsible for coordination and collaboration to develop the Solid specifications and the implementation of the Solid specifications as well as the Solid Advisory Board. The Solid Manager is responsible for moderating the W3C Solid Community Group calls. The Solid Manager is responsible for keeping the W3C Solid Community Group information up to date including Solid solutions and contributors as well as encouraging and supporting Solid Event organisers. The Solid Manager is responsible for coordinating Solid User testing. The Solid Manager has admin rights of all Solid repositories. 
 
-## Core Contributor
-Solid Core Contributors provide support, guidance, oversight, and contributions to Solid [projects](https://github.com/orgs/solid/projects) and standards in furtherance of the governing vision as defined by the Community Leader. They have admin rights on all Solid repositories, and are expected to participate in regular community group meetings, and maintain availability for project specific collaboration as needed.
+## Solid Specification Repositories Manager
+The Solid Specification Repository Manager is responsible for keeping the properties of their Solid specification repositories well-organised and communicating any changes clearly and publicly. The Solid Specification Repository Manager has admin rights of the Solid specification repositories and is expected to provide resolution and a defined route forward on any difference of opinion that may occur.
 
-## Repository Manager
-The Repository Manager is responsible for keeping the properties of their specific repository well-organized and communicating any changes clearly and publicly. The Repository Manager has admin rights of the repository they manage and is expected to attend the weekly recurring Solid support meeting.
+## Solid Experts 
+The Solid Experts are responsible for providing support to those looking to implement the Solid specification. 
 
-## Project Release Manager
-The Project Release Manager is responsible for determining the scope of a [project](https://github.com/orgs/solid/projects) as well as supporting the coordination between the Project Core Contributors and deciding on the final release. The Project Release Manager will ensure that any issues and pull requests related to their project are assigned to project core contributors, ensure that those assigned are on the case, and are responsible for merging pull requests and closing issues associated to their project. A Project Release Manager has admin rights over the project they manage and are must attend the weekly recurring Solid support meeting. A Project Release Manager is responsible for sharing the agenda prior to the project meeting, incorporating suggestions to the agenda, sharing the minutes after the project meeting and moderating the weekly recurring project meeting.
-
-## Project Contributor
-A Project Contributor is working on a specific official Solid [project](https://github.com/orgs/solid/projects). Project Contributors may have issues assigned to them by the Project Release Manager. Project Core Contributors have admin rights of projects they are working on. Project Core Contributors are expected to attend the weekly recurring Solid support meeting and weekly recurring project meetings.  
-
-## User Testing Manager
-The User Testing Coordinator is responsible for designing and running tests with the Solid User Testers as well as publishing test results publicly and clearly. The User Testing Manager is responsible for coordinating the User Testing Contributors and ensuring that tasks are assigned and follow up to ensure that these tasks are completed. The User Testing Manager is expected to share the agenda prior to the user testing meeting, incorporate suggestions to the agenda, share the minutes after the user testing meeting and moderate the weekly recurring user testing meeting.
-
-## User Testing Contributor
-The User Testing Contributor is responsible for supporting the User Testing Manager by completing tasks allocated to them by the User Testing Manager. User Testing Contributors are expected to attend the weekly recurring user testing meetings.
-
-## Solid User Testing Panelist
-Solid Panelists are individuals who are available for a range of tests over time to improve the Solid user experience. When there is a test set up by the Panel Coordinators, the Solid Manager will reach out to the relevant Solid Panelists to ask if they would like to participate in that particular test. Each test will take approximately 30 minutes, Solid Panelists are not obliged to participate in all tests, and Solid Panelists can stop being on the Solid Panel at any point. Tests will be designed to improve the Solid experience. Solid User Testing Panelists do not take part in the Solid support meeting nor in the solid/team gitter chat to avoid bias during the test.
+## Solid Advisor
+The Solid advisory board has the role of constructing a plan on how to uphold the original Solid values and mission. The plan needs to promote efficient, effective, inclusive, and transparent governance. The Solid advisory board should submit the plan to the Solid Leader with the support of the Solid Manager. Once the plan has been submitted the advisory board will be dismantled. Advisory board members will be appointed by the Solid Leader with the support of the Solid Manager. The advisory board will take part in several workshops to discuss the governance issues together. The Solid Manager will be coordinating the workshops. If you would like to suggest an issue to be addressed by the advisory board, please contact the Solid Manager.
 
 ## Solid Event Organiser
 The [Solid Event](solid-events.md) Organiser is responsible for organising and coordinating a Solid Event in a stated city. The position of Solid Event Organiser will be filled by an individual for as long as an event is scheduled in the future.
 
-# Solid Advisor
-The Solid advisory board has the role of constructing a plan on how to uphold the original Solid values and mission. The plan needs to promote efficient, effective, inclusive, and transparent governance. The Solid advisory board should submit the plan to the Solid Leader with the support of the Solid Manager. Once the plan has been submitted the advisory board will be dismantled. Advisory board members will be appointed by the Solid Leader with the support of the Solid Manager. The advisory board will take part in several workshops to discuss the governance issues together. The Solid Manager will be coordinating the workshops. If you would like to suggest an issue to be addressed by the advisory board, please contact the Solid Manager.
-
 ## Individuals currently occupying roles
-Find out any [associations](associations.md) individuals occupying these roles have to other organisations.
 
 * **Solid Leader** - [Tim Berners-Lee](https://github.com/timbl)
 
 * **Solid Manager** - [Mitzi László](https://github.com/Mitzi-Laszlo)
 
-* **Core Contributor** - [Ruben Verborgh](https://github.com/RubenVerborgh), [Justin Bingham](https://github.com/justinwb), [Arne Hassel](https://github.com/megoth_twitter), [Kjetil Kjernsmo](https://github.com/kjetilk)
+* **Solid Specification Repositories Manager** - [Kjetil Kjernsmo](https://github.com/kjetilk)
 
-* **Repository Manager** -
+* **Solid Experts** - [Ruben Verborgh](https://github.com/RubenVerborgh), [Justin Bingham](https://github.com/justinwb)
 
-webid-oidc-spec, oidc-auth-manager, solid-multi-rp-client, folder-pane, pane-registry, oidc-rs, keychain, solid-pane, solid-notifications, solid-profile-ui, solid-connections-ui, pane-source, jose, solid-inbox, oidc-op, solid-tif, solid-client, oidc-rp, issue-panes, solid, solid-idp-list, kvplus-files, solid-email, oidc-web, solid-sign-up, solid, takeout-import, node-solid-ws, solid-auth-tls,  solid-auth-oidc, meeting-pane, solid-dips, solid-cli, solid-web-client, solid-permissions, acl-check, node-solid-server Repository Manager: [Kjetil Kjernsmo](https://github.com/kjetilk)
+* **Solid Advisors** - a list of candidates is being put forward
 
-solid-auth-client, wac-allow, mavo-solid, solid-auth-client, ldflex-playground, query-ldflex, react-components, profile-viewer-react Repository Manager: @RubenVerborgh
-
-community, solid-tutorial-intro, solid-tutorial-angular, solid-tutorial-rdflib.js, profile-viewer-tutorial, understanding-linked-data, solid-tutorial-pastebin, web-summit-2018, intro-to-solid-slides, releases, solid-architecture, user guide, solid-namespace, solid-platform, solid-spec, web-access-control-spec, solid-apps, and solid.mit.edu Repository Manager: [Mitzi László](https://github.com/Mitzi-Laszlo)
-
-vocab Repository manager: @csarvan
-
-solid, solid-panes, solid-ui, mashlib, Repository Manager: [Tim Berners-Lee](https://github.com/timbl)
-
-* **Project Release Manager**
-
-[ASAP on Server](https://github.com/orgs/solid/projects/2) - [Kjetil Kjernsmo](https://github.com/kjetilk)
-
-[NSS - 5.0.0](https://github.com/orgs/solid/projects/1)  - [Kjetil Kjernsmo](https://github.com/kjetilk)
-
-[Solid Chat](https://github.com/orgs/solid/projects/3) - [Tim Berners-Lee](https://github.com/timbl)
-
-* **Project  Conntributor**
-[ASAP on Server](https://github.com/orgs/solid/projects/2) - [[Arne Hassel](https://github.com/megoth_twitter)
-[NSS - 5.0.0](https://github.com/orgs/solid/projects/1)  - [Arne Hassel](https://github.com/megoth_twitter)
-[Solid Chat](https://github.com/orgs/solid/projects/3) - [Mitzi László](https://github.com/Mitzi-Laszlo)
-
-* **User Testing Manager** - [Tony Morelli](https://github.com/tony-morelli)
-
-* **Solid User Testing Panelists** - Eric Prud’hommeaux, Eduardo Ibacache Rodriguez, Teodora Petkova,  David Booth, Pat McBennett
-
-* **Solid Event Organiser** - see upcoming organisers for upcoming [Solid Events](solid-events.md)
-
-* **Solid Advisors** -
+* **Solid Event Organiser** - see Solid Events to find out the event organiser of each


### PR DESCRIPTION
The pull request to edit the github.com/solid/information suggests to give an overview of the GitHub.com/solid account. The Solid Team is therefore more focused on the Solid specifications because the implementation of the Solid specification is done though projects and the Project scopes and leaders are defined under the GitHub projects.

In practice the user testing is being carried out by the Solid Manager so perhaps should be updated to reflect this. 

The Solid Contributors involved in the implementation of the spec are listed in the W3C wiki as well as the Solid GitHub repositories. The Solid Contributors involved in the specification are listed in the open source licence to recognise their contribution. Solid Contributors have been listed as Solid Experts.