### PR TITLE
Create w3c-solid-community-group.md

### DIFF
--- a/w3c-solid-community-group.md
+++ b/w3c-solid-community-group.md
@@ -1,0 +1,36 @@
+__NOTOC__
+
+The Solid Specifications ([https://github.com/solid/solid-spec Solid], [https://github.com/solid/web-access-control-spec Web Access Control], and [https://github.com/solid/webid-oidc-spec WebID OIDC]) describe how to decentralise power on the web to ensure that the web is used for the global public interest as defined by the Solid values.
+
+=== Solid Values===
+* Interoperability: Data should be interoperable to ensure that individuals or legal entities are able to self-determine independently of the technical possibilities. Technical hurdles should not be used as an excuse to not provide interoperability.
+* Self Determination: People and legal entities should be given the tools for self-determination. Self-determination involves the app user controlling data generated as a result of using an application, rather than the developer or owner of the application. Data control includes deciding where the data is stored as well as who sees what data, for what purpose, when. No individual should make a decision on behalf of another individual without consultation and ensuring that the individually is equipped with the necessary information to make an informed decision on the matter at hand that does not take advantage of convenience nudging.
+* Equal Access: There should be equal access to the web by all individuals both for consumption and creation. Although, for example, development, may take education, this education should be freely available and accessible by all.
+* Sourcing: It should be easy to find the source of a piece of data so that one can judge the trustworthiness of the data.
+* Public Value: The web should serve humanity to become more functional through collaboration leading toward mutual benefit. The long-term public interest should be given priority over the short-term private interest.
+* Connecting: An individual or legal entity should be able to connect data they control to the data others control.
+
+== Solid Specifications Changes ==
+
+Anyone can suggest a change to the Solid specification by joining the [W3C Solid Community Group](https://www.w3.org/information/solid/wiki/Main_Page) and raising a suggestion as an item in the [agenda](https://www.w3.org/community/solid/wiki/Meetings) of the weekly call, submitting a pull request or issue to the GitHub repositories of the Solid specification, and writing an email to W3C Solid Community Group mailing list public-solid@w3.org. 
+
+The [Solid Team](solid-team.md) supports the developement of the Solid specifications. The roles and responsibilites of the Solid Team are defined by the Solid Leader who also appoints individuals to those roles. If you would like to apply for a role, [contact the Solid Manager](solid-team.md) with your CV and motivation statement.
+
+Changes to the spec are made using the following process: 
+
+Step 1. Making a Suggestion
+	If you would like to make a suggestion for a speific change to code or text submit a pull request and if you would like to raise a general point open an [issue](https://github.com/solid/information/tree/master/.github/ISSUE_TEMPLATE). 
+	
+ Step 2. Inviting a Conversation around your Suggestion to Find Consensus
+	  Let others know about your suggestion by posting it on [solid/suggestions](https://gitter.im/solid/suggestions). Solid/suggestions is not a place to talk about the suggestion, this happens in the pull request or issue itself.How long does it take to process a suggestions? Pull requests and issues associated to the the spec (i.e. [solid spec](https://github.com/solid/solid-spec), [web access control spec](https://github.com/solid/web-access-control-spec), and [webid oidc spec](https://github.com/solid/webid-oidc-spec)) and the [Solid information repo](https://github.com/solid/information) need to be open for a minimum of three days to give other a chance to share their opinion to be considered. Pull requests and issues associated to all other repos can be closed immediately and do not have a minimum time they have to be left open unless they deviate from the spec in which case they need to be open for a minimum of three days. 
+ 
+ Step 3. Coming to a Conclusion through Compromise  
+ 	Who is responsible for processing the suggestion? The repository manager of the repository to which the suggestion pertains to will be responsible for merging and closing the pull request or issue. If there is a difference of opinion, parties are encouraged to talk to find a compromise. If a compromise cannot be met the Solid Leader will make the final judgement.
+
+== Implementation of the Solid Specifications==
+
+Anyone can implement the Solid Specifications. To see who has built what or to let others know what you have built look at the list of [Solid Solutions](https://www.w3.org/community/solid/wiki/Main_Page#Solid_Solutions). [Solid World](https://www.eventbrite.com/e/solid-world-tickets-53692744444?aff=erellivmlt) is a podcast where you can get up to speed with Solid and tune into the latest conversations. You can also read the latest [status update](https://github.com/solid/information/blob/master/status.md).   
+
+== Solid Press ==
+
+The Solid Team occasionally give talks or write articles. You can find out about [upcoming talks](https://github.com/solid/information/blob/master/solid-team-talks.md) as well as see recordings of past talks on [Solid Resources](https://github.com/solid/information/blob/master/solid-resources.md). If you would like to invite one of the [Solid team](https://github.com/solid/information/blob/master/solid-team.md) for public speaking or for an interview for an article please [contact the Solid Manager](https://github.com/solid/information/blob/master/solid-roles.md) and provide the details. Solid Events provide an opportunity for anyone to meet and talk about Solid in person. Anyone can organise a Solid Event. If you are thinking about running a Solid Event in your city below is some guidance from previous Solid Event Organisers. If you have run a Solid Event, please contribute to the guidance information and share your learnings. 

--- a/w3c-solid-community-group.md
+++ b/w3c-solid-community-group.md
@@ -1,8 +1,7 @@
 __NOTOC__
 
-The Solid Specifications ([https://github.com/solid/solid-spec Solid], [https://github.com/solid/web-access-control-spec Web Access Control], and [https://github.com/solid/webid-oidc-spec WebID OIDC]) describe how to decentralise power on the web to ensure that the web is used for the global public interest as defined by the Solid values.
+Solid aims to decentralise power on the web to ensure that the web is used for the global public interest as defined by the Solid values. The Solid values are: 
 
-=== Solid Values===
 * Interoperability: Data should be interoperable to ensure that individuals or legal entities are able to self-determine independently of the technical possibilities. Technical hurdles should not be used as an excuse to not provide interoperability.
 * Self Determination: People and legal entities should be given the tools for self-determination. Self-determination involves the app user controlling data generated as a result of using an application, rather than the developer or owner of the application. Data control includes deciding where the data is stored as well as who sees what data, for what purpose, when. No individual should make a decision on behalf of another individual without consultation and ensuring that the individually is equipped with the necessary information to make an informed decision on the matter at hand that does not take advantage of convenience nudging.
 * Equal Access: There should be equal access to the web by all individuals both for consumption and creation. Although, for example, development, may take education, this education should be freely available and accessible by all.
@@ -10,27 +9,48 @@ The Solid Specifications ([https://github.com/solid/solid-spec Solid], [https://
 * Public Value: The web should serve humanity to become more functional through collaboration leading toward mutual benefit. The long-term public interest should be given priority over the short-term private interest.
 * Connecting: An individual or legal entity should be able to connect data they control to the data others control.
 
-== Solid Specifications Changes ==
+The aim of the [W3C Solid Community Group](https://www.w3.org/community/solid/) is to publish Solid specifications describing how to build Solid as well as coordinate the collaboration between those who are building Solid. 
 
-Anyone can suggest a change to the Solid specification by joining the [W3C Solid Community Group](https://www.w3.org/information/solid/wiki/Main_Page) and raising a suggestion as an item in the [agenda](https://www.w3.org/community/solid/wiki/Meetings) of the weekly call, submitting a pull request or issue to the GitHub repositories of the Solid specification, and writing an email to W3C Solid Community Group mailing list public-solid@w3.org. 
+# Solid Specifications
+The Solid Specifications can be found on: 
 
+* [https://github.com/solid/solid-spec Solid]
+* [https://github.com/solid/web-access-control-spec Web Access Control]
+* [https://github.com/solid/webid-oidc-spec WebID OIDC]) 
+
+# The Solid Team 
 The [Solid Team](solid-team.md) supports the developement of the Solid specifications. The roles and responsibilites of the Solid Team are defined by the Solid Leader who also appoints individuals to those roles. If you would like to apply for a role, [contact the Solid Manager](solid-team.md) with your CV and motivation statement.
+
+# Solid Specifications Changes
+Anyone can suggest a change to the Solid specification by joining the [W3C Solid Community Group](https://www.w3.org/information/solid/wiki/Main_Page) and raising a suggestion as an item in the [agenda](https://www.w3.org/community/solid/wiki/Meetings) of the weekly call, submitting a pull request or issue to the GitHub repositories of the Solid specification, and writing an email to W3C Solid Community Group mailing list public-solid@w3.org. 
 
 Changes to the spec are made using the following process: 
 
 Step 1. Making a Suggestion
-	If you would like to make a suggestion for a speific change to code or text submit a pull request and if you would like to raise a general point open an [issue](https://github.com/solid/information/tree/master/.github/ISSUE_TEMPLATE). 
+	If you would like to make a suggestion for a speific change to code or text submit a pull request and if you would like to raise a general point open an [issue](https://github.com/solid/information/tree/master/.github/ISSUE_TEMPLATE). Pull requests and issues associated to the the Solid specification (i.e. [solid spec](https://github.com/solid/solid-spec), [web access control spec](https://github.com/solid/web-access-control-spec), and [webid oidc spec](https://github.com/solid/webid-oidc-spec)) need to be open for a minimum of three days to give other a chance to share their opinion to be considered.
 	
  Step 2. Inviting a Conversation around your Suggestion to Find Consensus
-	  Let others know about your suggestion by posting it on [solid/suggestions](https://gitter.im/solid/suggestions). Solid/suggestions is not a place to talk about the suggestion, this happens in the pull request or issue itself.How long does it take to process a suggestions? Pull requests and issues associated to the the spec (i.e. [solid spec](https://github.com/solid/solid-spec), [web access control spec](https://github.com/solid/web-access-control-spec), and [webid oidc spec](https://github.com/solid/webid-oidc-spec)) and the [Solid information repo](https://github.com/solid/information) need to be open for a minimum of three days to give other a chance to share their opinion to be considered. Pull requests and issues associated to all other repos can be closed immediately and do not have a minimum time they have to be left open unless they deviate from the spec in which case they need to be open for a minimum of three days. 
+	  Raise a point in the W3C Solid Community Group [agenda](https://www.w3.org/community/solid/wiki/Meetings) to present and talk about your suggestion during the weekly call. 
  
  Step 3. Coming to a Conclusion through Compromise  
- 	Who is responsible for processing the suggestion? The repository manager of the repository to which the suggestion pertains to will be responsible for merging and closing the pull request or issue. If there is a difference of opinion, parties are encouraged to talk to find a compromise. If a compromise cannot be met the Solid Leader will make the final judgement.
+ 	If there is a difference of opinion, parties are encouraged to talk to find a compromise. The Solid Specification Repository Manageer is responsible for processing the suggestion to a change to the Solid specifications and deciding on the route forward. The repository manager of the repository to which the suggestion pertains to will be responsible for merging and closing the pull request or issue.  If a compromise cannot be met the Solid Leader will make the final judgement.
 
-== Implementation of the Solid Specifications==
+# Implementation of the Solid Specifications
 
-Anyone can implement the Solid Specifications. To see who has built what or to let others know what you have built look at the list of [Solid Solutions](https://www.w3.org/community/solid/wiki/Main_Page#Solid_Solutions). [Solid World](https://www.eventbrite.com/e/solid-world-tickets-53692744444?aff=erellivmlt) is a podcast where you can get up to speed with Solid and tune into the latest conversations. You can also read the latest [status update](https://github.com/solid/information/blob/master/status.md).   
+Anyone can implement the Solid Specifications. To see who has built what or to let others know what you have built look at the list of [Solid Solutions](https://www.w3.org/community/solid/wiki/Main_Page). Solid World is a podcast where you can get up to speed with Solid and tune into the latest conversations which are also available in written form. 
 
-== Solid Press ==
+# Solid Press
 
-The Solid Team occasionally give talks or write articles. You can find out about [upcoming talks](https://github.com/solid/information/blob/master/solid-team-talks.md) as well as see recordings of past talks on [Solid Resources](https://github.com/solid/information/blob/master/solid-resources.md). If you would like to invite one of the [Solid team](https://github.com/solid/information/blob/master/solid-team.md) for public speaking or for an interview for an article please [contact the Solid Manager](https://github.com/solid/information/blob/master/solid-roles.md) and provide the details. Solid Events provide an opportunity for anyone to meet and talk about Solid in person. Anyone can organise a Solid Event. If you are thinking about running a Solid Event in your city below is some guidance from previous Solid Event Organisers. If you have run a Solid Event, please contribute to the guidance information and share your learnings. 
+The Solid Team and W3C Solid Community Group occasionally give talks or write articles. 
+
+Solid Events provide an opportunity for anyone to meet and talk about Solid in person. Anyone can organise a Solid Event. If you are thinking about running a Solid Event in your city below is some guidance from previous Solid Event Organisers. If you have run a Solid Event, please contribute to the guidance information and share your learnings with the Solid Manager to incorporate. If you are organising a Solid Event, let others know about it by publishing the details on the [W3C Solid Community Group wiki](https://www.w3.org/community/solid/wiki/Main_Page#Solid_Events)
+
+## Logistics
+
+Partnering with existing meetups or organisations that regularly host events has the benefit of learning from their experience. Logistics can include anything from providing a space and equipment such as a projector or sound system. Partnering with experienced event organisers may also be useful in promoting the event itself. If the previous events are aligned with Solid perhaps their audiences would be interested in joining.
+
+## Solid Event Formats
+
+* Solid Users: If your event is general and targeted to a wide audience using Solid or looking to use Solid, it is important that you cover What, Why, How, When, described so anyone can understand. What is Solid? Why should I use Solid? How can I use it? Describe the known upcoming roadmap. Sometimes it is useful to talk about the core values that define the Solid design. Value based conversations can be an excellent route to moving these conversations forward. It can be useful to define a theme or opening question. One way to focus the conversation is to set it up as a debate panel with multiple teams defending a specific perspective. Allocating people to defend perspectives they do not neccesarily agree with is a good way to open the mind and expand the debate.
+* Entrepreneur-Investor Pitching: One format is to invite local entrepreneurs and developers to pitch an idea for a Solid app or Pod Provider. You can also invite investors to pitch why their funds are appropriate for Solid values.
+* Hackthons: Hackathons are great for passing on knowledge between those who are familiar with Solid to those who are learning. It is useful to have a concrete target for your hackathon that you can work towards together.


### PR DESCRIPTION
Would be good to have the core information on https://www.w3.org/community/solid/ to be the same as in the solid/information repo and make sure it is complete.