### PR TITLE
Fix invalid header link from #44

### DIFF
--- a/solid-team.md
+++ b/solid-team.md
@@ -3,7 +3,7 @@ This document aims to identify the various roles within Solid, and the responsib
 
 - [Solid Leader](#solid-leader)
 - [Solid Manager](#solid-manager)
-- [Solid Specifications Repository Manager](#repository-manager)
+- [Solid Specifications Repository Manager](#solid-specifications-repository-manager)
 - [Solid Experts](#solid-experts)
 - [Solid Advisor](#solid-advisor)
 - [Solid Event Organiser](#solid-event-organiser)


### PR DESCRIPTION
@Mitzi-Laszlo This should [fix the master branch](https://travis-ci.org/solid/information/builds/514745408). The reason travis didn't catch this is because travis only runs on pull requests from when it was enabled. All of the current PRs except #87 were created before [kietilk enabled travis on Mon afternoon](https://github.com/solid/information/pull/73#issuecomment-478724088) so for those PRs you won't know if there are invalid links until they are merged to master. Starting with #87, PRs will have a pass/fail indicator for the travis build. I would recommend merging this soon so that future PRs (and #87) don't fail