### PR TITLE
Remove Dev Versions of Pod Providers

### DIFF
--- a/pod-providers.md
+++ b/pod-providers.md
@@ -1,20 +1,15 @@
 # POD providers for Solid
 
-## Running node-solid-server
-
-### Stable releases
-
 |               Link                |    Responsible for Domain Name and Terms of Use     |             Responsible for Hosting               | Location of Hosting | Solid Server Version |
 |-----------------------------------|:---------------------------------------------------:|:-------------------------------------------------:|:-------------------:|:--------------------:|
 | https://inrupt.net/               | [Inrupt, Inc.](https://inrupt.com/terms-of-service) |         [Amazon](https://aws.amazon.com)          |         USA         |          ??          |
 | https://solid.community/          |                          ??                         |                        ??                         |         ??          |          ??          |
-| https://solidtest.space/          |                          ???                         |                        ??                         |         ??          |          ??          |
+
 
 ### Development releases 
 
 |               Link                |    Responsible for Domain Name and Terms of Use     |             Responsible for Hosting               | Location of Hosting | Solid Server Version |
 |-----------------------------------|:---------------------------------------------------:|:-------------------------------------------------:|:-------------------:|:--------------------:|
-| https://dev.inrupt.net/           | [Inrupt, Inc.](https://inrupt.com/terms-of-service) |         [Amazon](https://aws.amazon.com)          |         USA         |          5.0.0-beta.6          |
 | https://solid.authing.cn/         |                          ??                         |                        ??                         |         ??          |          ??          |
 | https://solid.openlinksw.com:8444 |  [OpenLink Software](https://www.openlinksw.com/)   | [OpenLink Software](https://www.openlinksw.com/)  |         USA         |        NSS 4.x       |
 | https://solid.openlinksw.com:8445 |  [OpenLink Software](https://www.openlinksw.com/)   | [OpenLink Software](https://www.openlinksw.com/)  |         USA         |        NSS 5.x       |

--- a/pod-providers.md
+++ b/pod-providers.md
@@ -1,15 +1,19 @@
-# POD providers for Solid
+# Solid POD Providers
 
 |               Link                |    Responsible for Domain Name and Terms of Use     |             Responsible for Hosting               | Location of Hosting | Solid Server Version |
 |-----------------------------------|:---------------------------------------------------:|:-------------------------------------------------:|:-------------------:|:--------------------:|
 | https://inrupt.net/               | [Inrupt, Inc.](https://inrupt.com/terms-of-service) |         [Amazon](https://aws.amazon.com)          |         USA         |          ??          |
 | https://solid.community/          |                          ??                         |                        ??                         |         ??          |          ??          |
-
-
-### Development releases 
-
-|               Link                |    Responsible for Domain Name and Terms of Use     |             Responsible for Hosting               | Location of Hosting | Solid Server Version |
-|-----------------------------------|:---------------------------------------------------:|:-------------------------------------------------:|:-------------------:|:--------------------:|
 | https://solid.authing.cn/         |                          ??                         |                        ??                         |         ??          |          ??          |
-| https://solid.openlinksw.com:8444 |  [OpenLink Software](https://www.openlinksw.com/)   | [OpenLink Software](https://www.openlinksw.com/)  |         USA         |        NSS 4.x       |
-| https://solid.openlinksw.com:8445 |  [OpenLink Software](https://www.openlinksw.com/)   | [OpenLink Software](https://www.openlinksw.com/)  |         USA         |        NSS 5.x       |
+
+# Experimental Solid Servers
+
+The following servers are intended for experimental use and testing of new, unstable instances of a Solid server implementation. There should be no expectation of consistent availability for any server in this list, nor should there be an expectation of reliability or availability of data stored within. Created accounts may be deleted, or corrupted, based on experimental work.
+
+In short, these are made for testing the latest, bleeding edge features and capabilities. Unless that's what you're doing, don't use any of these.
+
+|               Link                |               Responsible for Hosting               | Location of Hosting | Solid Server Version |
+|-----------------------------------|:---------------------------------------------------:|:-------------------------------------------------:|:-------------------:|:--------------------:|
+| https://solid.openlinksw.com:8444 |   [OpenLink Software](https://www.openlinksw.com/)  |         USA         |        NSS 4.x       |
+| https://solid.openlinksw.com:8445 |   [OpenLink Software](https://www.openlinksw.com/)  |         USA         |        NSS 5.x       |
+| https://dev.inrupt.net |  [Inrupt, Inc.](https://www.inrupt.com/)  |         USA         |        NSS 5.x       |


### PR DESCRIPTION
Suggesting to remove these because they are specifically for the organisations running them to be able to test. Including them is creating confusion to the wider group.