### PR TITLE
Solid Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,64 @@
-The [Solid GitHub account](https://github.com/solid) was started by the [Solid academic project at MIT](https://solid.mit.edu). In summer 2018 the private company [inrupt](https://inrupt.com) based in Boston, USA, made significant contributions to the [Solid GitHub account](https://github.com/solid).
 
-The [Solid GitHub account](https://github.com/solid) includes the following. 
+
+The [Solid GitHub account](https://github.com/solid) was started by the [Solid academic project at MIT](https://solid.mit.edu) and today is run by the [Solid Team](https://github.com/solid/information/blob/master/solid-team.md) using defined processes.
+
+Solid aims to decentralise power on the web to ensure that the web is used for the global public interest by providing the Solid specification. 
 
 # Solid Specifications 
 The Solid specifications can be found in the following repositories: 
 * [Solid](https://github.com/solid/solid-spec)  
 * [Web Access Control](https://github.com/solid/web-access-control-spec) 
-* [WebID OIDC](https://github.com/solid/webid-oidc-spec) 
+* [WebID OIDC](https://github.com/solid/webid-oidc-spec)
 
-The [Solid Team](solid-team.md) works with the [W3C Solid Community Group](https://www.w3.org/community/solid/) (which you can also read about on the [Solid/information solid.md](https://github.com/solid/information/blob/master/w3c-solid-community-group.md) to support the development of the Solid specifications as well as coordinating those who are implementing the Solid. 
+# W3C Solid Community Group
+Anyone can implement the Solid specifications and is encouraged to [join the W3C SOlid Coommunity Group](https://www.w3.org/community/solid/) where the the development of the Solid specifications as well as coordinating those who are implementing the Solid is discussed. [Minutes of previous conversations and agendas of upcoming conversations of the W3C Solid community Group](https://www.w3.org/community/solid/wiki/Meetings) are publicly available. You can find a list of all organisations implementing the Solid specifications. 
 
-# Information about Solid
-Information about Solid  can be found in the following repos:
-information, vocab, solid-tutorial-intro, solid-tutorial-angular, solid-tutorial-rdflib.js, profile-viewer-tutorial, understanding-linked-data, solid-tutorial-pastebin, web-summit-2018, intro-to-solid-slides, releases, solid-architecture, user guide, solid-namespace, solid-platform, solid-apps, and solid.mit.edu
+ # Solid Apps
+List of [Solid Apps](https://github.com/solid/solid-apps)
 
-Currently there is no defined individual responsible for these repositories, although anyone can suggest to update the information by submitting a pull request or issue. If you would like to become responsible for these repositories including keeping the information up to date and incorporating suggestions from pull requests and issues contact the Solid Manager. The information in these repositories can also be found in the [W3C Solid Community Group](https://www.w3.org/community/solid/). 
+ # Pod Providers
+ List of Pod Providers
 
-# Implementations of the Solid Specifications
+# Solid Projects 
+[Solid Projects](https://github.com/orgs/solid/projects) are implementations of the Solid specification within Solid Github account. Anyone can submit a project proposal to the Solid Team including a description of the project name, scope, manager, contributors and names of associated repositories needed. The Project Manager is responsible for determining the scope of a [project](https://github.com/orgs/solid/projects) as well as supporting the coordination of the Project Team Member. The Project Manager will ensure that any issues and pull requests related to their project are assigned to Project Team Member, ensure that those assigned are on the case, and are responsible for merging pull requests and closing issues associated to their project. A Project Manager has admin rights over the project they manage. A Project Team Member is working on a specific official Solid [project](https://github.com/orgs/solid/projects). Project Team Members may have issues assigned to them by the Project  Manager. Project Team Members have admin rights of projects they are working on. If you would like to join an existing project, reach out to corresponding Project Manager. If you would like to start a new project, reach out to the Solid Manager with your project proposal including a defined aim, Project Manager, and Project Team.
+
 The implementation of the Solid specifications can be found in the following repos:
 oidc-auth-manager, solid-multi-rp-client, folder-pane, pane-registry, oidc-rs, keychain, solid-pane, solid-notifications, solid-profile-ui, solid-connections-ui, pane-source, jose, solid-inbox, oidc-op, solid-tif, solid-client, oidc-rp, issue-panes, solid, solid-idp-list, kvplus-files, solid-email, oidc-web, solid-sign-up, solid, takeout-import, node-solid-ws, solid-auth-tls,  solid-auth-oidc, meeting-pane, solid-dips, solid-cli, solid-web-client, solid-permissions, acl-check, node-solid-server, solid-auth-client, wac-allow, mavo-solid, solid-auth-client, ldflex-playground, query-ldflex, react-components, profile-viewer-react, solid, solid-panes, solid-ui, mashlib
 
-[Projects](https://github.com/orgs/solid/projects) with defined aims, managers, and teams, as described in the project descriptions work on the implementations of the Solid specification. The Project Manager is responsible for determining the scope of a [project](https://github.com/orgs/solid/projects) as well as supporting the coordination of the Project Team Member. The Project Manager will ensure that any issues and pull requests related to their project are assigned to Project Team Member, ensure that those assigned are on the case, and are responsible for merging pull requests and closing issues associated to their project. A Project Manager has admin rights over the project they manage. A Project Team Member is working on a specific official Solid [project](https://github.com/orgs/solid/projects). Project Team Members may have issues assigned to them by the Project  Manager. Project Team Members have admin rights of projects they are working on. If you would like to join an existing project, reach out to corresponding Project Manager. If you would like to start a new project, reach out to the Solid Manager with your project proposal including a defined aim, Project Manager, and Project Team.
+# Solid Learning Material
+* [Solid Tutorial Intro](https://github.com/solid/solid-tutorial-intro)
+* [Solid Tutorial Angular](https://github.com/solid/solid-tutorial-angular)
+* [Solid Tutorial rdflib](https://github.com/solid/solid-tutorial-angular.js)
+* [Solid Tutorial Profile Viewer Tutorial](https://github.com/solid/profile-viewer-tutorial)
+* [Solid Tutorial Understanding Linked Data](https://github.com/solid/understanding-linked-data)
+* [Solid Tutorial Pastebin](https://github.com/solid/solid-tutorial-pastebin)
+* [Solid Vocabularies](https://github.com/solid/vocab)
+* [Releases](https://github.com/solid/releases)
 
-# Gitter Chat 
-The  Gitter chats associated to the [Solid GitHub account](https://github.com/solid) include: 
+# Solid Events 
+Solid Events provide an opportunity for anyone to meet and talk about Solid in person. Anyone can organise a Solid Event for which you can find guidance and a list of upcoming events. 
 
-* solid/chat: a place to talk about all things solid, open to all. 
-* solid/solid-spec: a place to talk about the solid spec, open to all. Note that actual changes to the Solid specification happen through the processes and channels explained in the W3C Solid Community Group
-* node-solid-server: a place to talk about the server implementation of the Solid specification, open to all. 
-* app-development: a place to talk about the implementation of the Solid specification when building applications, open to all. 
-* site-and-docs: a place to talk about sites and documentation associated to the solid GitHub account
+# Solid Resources 
+If you know of any grants or channels to apply to resources that would allow developers to focus on building their application on solid, please do share them. 
+
+# Solid Press 
+You can find a list of mentions of Solid in the press. 
+
+# Solid Conversations
+The  Gitter chats associated to the [Solid GitHub account](https://github.com/solid) include 
+
+* solid/chat: a place to talk about all things Solid
+* solid/solid-spec: a place to talk about the Solid specification. Note that actual changes to the Solid specification happen through the official processes. 
+
+Groups implementing the Solid  have a dedicated channel based on the implemtatnion. 
+* solid/app-development: Solid app developers can share tips and ask questions on this channel 
+* solid/pod-providers: coming soon
+* solid/events: coming soon
+
+Solid Projects have dedicated chat channels. 
+* solid/node-solid-server: originally a place to talk about [Solid Project NSS-v5.0.0](https://github.com/orgs/solid/projects/1) and now a dedicated space for [Solid Project ASAP on Server](https://github.com/orgs/solid/projects/2)
+* solid-panes: coming soon
+
+Solid Challenges have dedicated channels associated to them
 * solid/chat-app: a place to talk about the implementation of the Solid specification when building chat applications
+* solid/blog-app

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-
-
 The [Solid GitHub account](https://github.com/solid) was started by the [Solid academic project at MIT](https://solid.mit.edu) and today is run by the [Solid Team](https://github.com/solid/information/blob/master/solid-team.md) using defined processes.
 
-Solid aims to decentralise power on the web to ensure that the web is used for the global public interest by providing the Solid specification. 
+Solid aims to decentralise power on the web to ensure that the web is used for the global public interest by providing the Solid specification. Read more about the [Solid values](https://github.com/solid/information/blob/master/solid-values.md). 
 
 # Solid Specifications 
 The Solid specifications can be found in the following repositories: 
@@ -35,9 +33,10 @@ oidc-auth-manager, solid-multi-rp-client, folder-pane, pane-registry, oidc-rs, k
 * [Solid Tutorial Pastebin](https://github.com/solid/solid-tutorial-pastebin)
 * [Solid Vocabularies](https://github.com/solid/vocab)
 * [Releases](https://github.com/solid/releases)
+* [Userguide](https://github.com/solid/userguide)
 
 # Solid Events 
-Solid Events provide an opportunity for anyone to meet and talk about Solid in person. Anyone can organise a Solid Event for which you can find guidance and a list of upcoming events. 
+[Solid Events](https://github.com/solid/information/blob/master/solid-events.md) provide an opportunity for anyone to meet and talk about Solid in person. Anyone can organise a Solid Event. If you are thinking about running a Solid Event in your city below is some guidance from previous Solid Event Organisers. If you have run a Solid Event, please contribute to the guidance information and share your learnings with the Solid Manager to incorporate. If you are organising a Solid Event, let others know about it by publishing it. 
 
 # Solid Resources 
 If you know of any grants or channels to apply to resources that would allow developers to focus on building their application on solid, please do share them. 
@@ -52,7 +51,7 @@ Read all past questions or ask a new question on the [Frequently Unanswered Ques
 Each repository has a license of which you can get an [overview](https://github.com/solid/information/blob/master/license.md). 
 
 # Solid Press 
-You can find a list of [mentions of Solid in the press](https://github.com/solid/information/blob/master/solid-resources.md). The Solid Team occasionally give talks. Find out about [upcoming Solid Team talks](https://github.com/solid/information/blob/master/solid-team-talks.md). Contact the Solid Team if you are interested in inviting them a a speaker at your event.   
+You can find a list of [mentions of Solid in the press](https://github.com/solid/information/blob/master/solid-resources.md). The Solid Team and W3C Solid Community Group occasionally give talks or write articles. Find out about [upcoming Solid Team talks](https://github.com/solid/information/blob/master/solid-team-talks.md). Contact the Solid Team if you are interested in inviting them a a speaker at your event.   
 
 # Solid Conversations
 The  Gitter chats associated to the [Solid GitHub account](https://github.com/solid) include 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Anyone can implement the Solid specifications and is encouraged to [join the W3C
 List of [Solid Apps](https://github.com/solid/solid-apps)
 
  # Pod Providers
- List of Pod Providers
+ You read more about [self hosting](https://github.com/solid/information/blob/master/self-hosting.md) or share your experience of self hosting a Pod. Alternatively, check out the list of [Pod Providers](https://github.com/solid/information/blob/master/pod-providers.md). 
 
 # Solid Projects 
 [Solid Projects](https://github.com/orgs/solid/projects) are implementations of the Solid specification within Solid Github account. Anyone can submit a project proposal to the Solid Team including a description of the project name, scope, manager, contributors and names of associated repositories needed. The Project Manager is responsible for determining the scope of a [project](https://github.com/orgs/solid/projects) as well as supporting the coordination of the Project Team Member. The Project Manager will ensure that any issues and pull requests related to their project are assigned to Project Team Member, ensure that those assigned are on the case, and are responsible for merging pull requests and closing issues associated to their project. A Project Manager has admin rights over the project they manage. A Project Team Member is working on a specific official Solid [project](https://github.com/orgs/solid/projects). Project Team Members may have issues assigned to them by the Project  Manager. Project Team Members have admin rights of projects they are working on. If you would like to join an existing project, reach out to corresponding Project Manager. If you would like to start a new project, reach out to the Solid Manager with your project proposal including a defined aim, Project Manager, and Project Team.
@@ -26,6 +26,7 @@ The implementation of the Solid specifications can be found in the following rep
 oidc-auth-manager, solid-multi-rp-client, folder-pane, pane-registry, oidc-rs, keychain, solid-pane, solid-notifications, solid-profile-ui, solid-connections-ui, pane-source, jose, solid-inbox, oidc-op, solid-tif, solid-client, oidc-rp, issue-panes, solid, solid-idp-list, kvplus-files, solid-email, oidc-web, solid-sign-up, solid, takeout-import, node-solid-ws, solid-auth-tls,  solid-auth-oidc, meeting-pane, solid-dips, solid-cli, solid-web-client, solid-permissions, acl-check, node-solid-server, solid-auth-client, wac-allow, mavo-solid, solid-auth-client, ldflex-playground, query-ldflex, react-components, profile-viewer-react, solid, solid-panes, solid-ui, mashlib
 
 # Solid Learning Material
+* [Developer Tools](https://github.com/solid/information/blob/master/developer-tools.md)
 * [Solid Tutorial Intro](https://github.com/solid/solid-tutorial-intro)
 * [Solid Tutorial Angular](https://github.com/solid/solid-tutorial-angular)
 * [Solid Tutorial rdflib](https://github.com/solid/solid-tutorial-angular.js)
@@ -41,8 +42,17 @@ Solid Events provide an opportunity for anyone to meet and talk about Solid in p
 # Solid Resources 
 If you know of any grants or channels to apply to resources that would allow developers to focus on building their application on solid, please do share them. 
 
+# Solid Logo and Terms 
+You can read a complete set of standardised definitions in the [Solid dictionary](https://github.com/solid/information/blob/master/solid-dictionary.md) and the [Solid Logo usage guidelines](https://github.com/solid/information/blob/master/solid-logo-usage-guidelines.md). 
+
+# FAQs 
+Read all past questions or ask a new question on the [Frequently Unanswered Questions](https://github.com/solid/information/blob/master/frequently-unanswered-questions.md) page. 
+
+# License 
+Each repository has a license of which you can get an [overview](https://github.com/solid/information/blob/master/license.md). 
+
 # Solid Press 
-You can find a list of mentions of Solid in the press. 
+You can find a list of [mentions of Solid in the press](https://github.com/solid/information/blob/master/solid-resources.md). The Solid Team occasionally give talks. Find out about [upcoming Solid Team talks](https://github.com/solid/information/blob/master/solid-team-talks.md). Contact the Solid Team if you are interested in inviting them a a speaker at your event.   
 
 # Solid Conversations
 The  Gitter chats associated to the [Solid GitHub account](https://github.com/solid) include 


### PR DESCRIPTION
There is a lot of information about Solid in multiple places which means it is difficult for newcomers to navigate. Also multiple wiki lists are emerging in multiple sites meaning the information is diverging and the energy to maintain the wiki being spread thin. 

My proposal would be to have GitHub.com/solid/information as a central place for Solid information. The delicate thing is to get everyone on board who has made other repos covering the same information that could fit into the solid/information repo or at least have links to it. My preference would be to get as much as possible into a single repo to make sure energy doesn't dissipate and spread too thin. The W3C wiki could simply reference GitHub.com/solid/information and focus on the W3C Solid Community Group meeting agenda and planning for the face-to-face. 

The readme is static information and the .md files are lists that need more regular updating. There are several links that would need to be added to .md files once this pull request is merged. 

This is just a proposal, suggestions more than welcome.